### PR TITLE
Enable work area scrolling and add resizable AI chat widget

### DIFF
--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import './styles/modern-layout.css';
 import AssignmentTray from './components/AssignmentTray';
 import WorkArea from './components/WorkArea';
-import TutorDock from './components/TutorDock';
+import ChatWidget from './components/ChatWidget';
 import Timeline from './components/Timeline';
 import { assignmentsData } from './data/exampleData';
 import type { Assignment, WorkTab, AppState } from './types';
@@ -134,7 +134,7 @@ function App() {
         submissions={state.submissions}
       />
 
-      <TutorDock
+      <ChatWidget
         mode={state.tutorMode}
         activeAssignment={state.activeAssignment}
         submissions={state.submissions}

--- a/apps/studio/src/components/ChatWidget.tsx
+++ b/apps/studio/src/components/ChatWidget.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import TutorDock from './TutorDock';
+import type { TutorDockProps } from '../types';
+
+const ChatWidget: React.FC<TutorDockProps> = (props) => {
+  const [open, setOpen] = useState(false);
+
+  if (!open) {
+    return (
+      <button
+        className="chat-widget-toggle"
+        onClick={() => setOpen(true)}
+      >
+        AI Chat
+      </button>
+    );
+  }
+
+  return (
+    <div className="chat-widget">
+      <button
+        className="chat-widget-close"
+        onClick={() => setOpen(false)}
+        aria-label="Close chat"
+      >
+        ×
+      </button>
+      <TutorDock {...props} />
+    </div>
+  );
+};
+
+export default ChatWidget;

--- a/apps/studio/src/components/ChatWidget.tsx
+++ b/apps/studio/src/components/ChatWidget.tsx
@@ -5,27 +5,31 @@ import type { TutorDockProps } from '../types';
 const ChatWidget: React.FC<TutorDockProps> = (props) => {
   const [open, setOpen] = useState(false);
 
-  if (!open) {
-    return (
-      <button
-        className="chat-widget-toggle"
-        onClick={() => setOpen(true)}
-      >
-        AI Chat
-      </button>
-    );
-  }
-
   return (
     <div className="chat-widget">
-      <button
-        className="chat-widget-close"
-        onClick={() => setOpen(false)}
-        aria-label="Close chat"
+      {open ? (
+        <button
+          className="chat-widget-close"
+          onClick={() => setOpen(false)}
+          aria-label="Close chat"
+        >
+          ×
+        </button>
+      ) : (
+        <button
+          className="chat-widget-toggle"
+          onClick={() => setOpen(true)}
+        >
+          AI Chat
+        </button>
+      )}
+      <div
+        className="chat-widget-body"
+        style={{ display: open ? 'block' : 'none' }}
+        aria-hidden={!open}
       >
-        ×
-      </button>
-      <TutorDock {...props} />
+        <TutorDock {...props} />
+      </div>
     </div>
   );
 };

--- a/apps/studio/src/styles/layout.css
+++ b/apps/studio/src/styles/layout.css
@@ -16,11 +16,11 @@ body {
 .layout {
   display: grid;
   grid-template-rows: 48px 1fr 120px;
-  grid-template-columns: 280px 1fr 360px;
+  grid-template-columns: 280px 1fr;
   grid-template-areas:
-    "header header header"
-    "tray work tutor"
-    "timeline timeline tutor";
+    "header header"
+    "tray work"
+    "timeline timeline";
   height: 100vh;
   background: #ffffff;
   overflow: hidden;
@@ -166,7 +166,7 @@ body {
 
 .work-content {
   flex: 1;
-  overflow: hidden;
+  overflow-y: auto;
   position: relative;
 }
 
@@ -329,7 +329,7 @@ body {
 /* Responsive design */
 @media (max-width: 1200px) {
   .layout {
-    grid-template-columns: 240px 1fr 300px;
+    grid-template-columns: 240px 1fr;
   }
 }
 
@@ -610,7 +610,7 @@ body {
   height: 100%;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow-y: auto;
 }
 
 .doc-editor-empty {
@@ -836,7 +836,7 @@ body {
   height: 100%;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow-y: auto;
 }
 
 .pdf-header,
@@ -887,6 +887,56 @@ body {
   background: white;
   border: 1px solid #e2e8f0;
   border-radius: 8px;
+}
+
+/* Floating AI chat widget */
+.chat-widget {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  width: 320px;
+  height: 400px;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  resize: both;
+  overflow: hidden;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+}
+
+.chat-widget .tutor-dock {
+  display: flex !important;
+  height: 100%;
+  width: 100%;
+  border-left: none;
+}
+
+.chat-widget-close {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+  background: transparent;
+  border: none;
+  font-size: 1.25rem;
+  cursor: pointer;
+}
+
+.chat-widget-toggle {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  background: #3b82f6;
+  color: white;
+  border: none;
+  border-radius: 9999px;
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  z-index: 1000;
 }
 
 .feature-icon {

--- a/apps/studio/src/styles/modern-layout.css
+++ b/apps/studio/src/styles/modern-layout.css
@@ -103,11 +103,11 @@ body {
 .layout {
   display: grid;
   grid-template-rows: 64px 1fr 140px;
-  grid-template-columns: 320px 1fr 400px;
+  grid-template-columns: 320px 1fr;
   grid-template-areas:
-    "header header header"
-    "tray work tutor"
-    "timeline timeline tutor";
+    "header header"
+    "tray work"
+    "timeline timeline";
   height: 100vh;
   background: var(--gray-100);
   overflow: hidden;
@@ -450,7 +450,7 @@ body {
 
 .work-content {
   flex: 1;
-  overflow: hidden;
+  overflow-y: auto;
   position: relative;
   background: #ffffff;
 }
@@ -771,7 +771,7 @@ body {
   
   /* Legacy layout styles */  
   .layout {
-    grid-template-columns: 280px 1fr 350px;
+    grid-template-columns: 280px 1fr;
   }
 }
 
@@ -788,7 +788,7 @@ body {
   
   /* Legacy layout styles */
   .layout {
-    grid-template-columns: 260px 1fr 320px;
+    grid-template-columns: 260px 1fr;
   }
   
   :root {
@@ -1018,7 +1018,7 @@ body {
   height: 100%;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow-y: auto;
 }
 
 .doc-editor-empty {
@@ -1371,7 +1371,7 @@ body {
   height: 100%;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow-y: auto;
 }
 
 .pdf-header,
@@ -1519,6 +1519,56 @@ body {
   border-color: var(--blue-500);
   background: var(--blue-50);
   color: var(--blue-700);
+}
+
+/* Floating AI chat widget */
+.chat-widget {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  width: 320px;
+  height: 400px;
+  background: #ffffff;
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  resize: both;
+  overflow: hidden;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+}
+
+.chat-widget .tutor-dock {
+  display: flex !important;
+  height: 100%;
+  width: 100%;
+  border-left: none;
+}
+
+.chat-widget-close {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+  background: transparent;
+  border: none;
+  font-size: 1.25rem;
+  cursor: pointer;
+}
+
+.chat-widget-toggle {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  background: var(--blue-500);
+  color: white;
+  border: none;
+  border-radius: 9999px;
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: var(--shadow-md);
+  z-index: 1000;
 }
 
 /* Print styles */


### PR DESCRIPTION
## Summary
- Allow document, PDF, and whiteboard tabs to scroll by switching hidden overflow to auto.
- Introduce a floating, resizable ChatWidget wrapping TutorDock for AI chat.
- Integrate ChatWidget into the app layout and streamline grid configuration.

## Testing
- `pnpm lint` *(fails: ESLint couldn't find configuration files)*
- `pnpm test` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_68986d1a7dbc832aa7e180b262f9f584